### PR TITLE
Fix for parent-child state machine calls

### DIFF
--- a/lib/starter.js
+++ b/lib/starter.js
@@ -64,6 +64,11 @@ const start = options => {
     args.push(options.waitTimeScale);
   }
 
+  if (options.stepFunctionsEndpoint) {
+    args.push('-stepFunctionsEndpoint');
+    args.push(options.stepFunctionsEndpoint);
+  }
+
   const child = spawn('java', args, {
     cwd: options.path,
     env: process.env


### PR DESCRIPTION
Hello,

This PR allows adding `-stepFunctionsEndpoint` argument when starting Step Functions Local.

### Background:

Been using [serverless-step-functions-local](https://github.com/codetheweb/serverless-step-functions-local/tree/43b19a347e0e6ed1a1c70e6313ee154cf7d2ef68) and it's working well locally for individual state machine runs.
However, when running a step machine that calls another step machine as a task, I'm getting this error message:

`{"Type":"ExecutionFailed","PreviousEventId":5,"ExecutionFailedEventDetails":{"Error":"StepFunctions-AWSStepFunctionsException","Cause":"The security token included in the request is invalid. (Service: AWSStepFunctions; Status Code: 400; Error Code: UnrecognizedClientException; Request ID: 72e40098-51a3-4a15-83b4-0d30b57c0f56; Proxy: null)"}}`

(Note: `--endpoint-url http://localhost:8083` was specified when running the `aws stepfunctions` command)

Adding the `-stepFunctionsEndpoint` argument with `http://localhost:8083` as the value did the trick and executed the child state machines.

Next Step: Pass the `stepFunctionsEndpoint` from serverless-step-functions-local [index.js#L96-L101](https://github.com/codetheweb/serverless-step-functions-local/blob/43b19a347e0e6ed1a1c70e6313ee154cf7d2ef68/index.js#L96-L101)